### PR TITLE
fix: make product_development_hours not nullable

### DIFF
--- a/functions/kpi_functions.sql
+++ b/functions/kpi_functions.sql
@@ -550,7 +550,7 @@ $$
 begin
 return query (
 SELECT 
-    SUM(time_entry.minutes)/60.0 AS hours
+    COALESCE(SUM(time_entry.minutes)/60.0, 0) AS hours
 FROM
     projects JOIN time_entry ON time_entry.project = projects.id
 WHERE


### PR DESCRIPTION
Caused KPI app to crash when there were not registered dev hours.

```
[
  {"from_date":"2020-10-01","to_date":"2021-03-31","payload":null},
  {"from_date":"2020-09-01","to_date":"2021-02-28","payload":1.00000000000000000000}
]
```