### PR TITLE
add read only user

### DIFF
--- a/sqitch/deploy/add_read_only_user.sql
+++ b/sqitch/deploy/add_read_only_user.sql
@@ -1,0 +1,13 @@
+-- Deploy floq:add_read_only_user to pg
+
+BEGIN;
+
+-- Set password before deploying and then remember to NOT COMMIT the change!
+CREATE USER read_only ENCRYPTED PASSWORD NULL;
+GRANT SELECT ON ALL TABLES IN SCHEMA public to read_only;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public to read_only;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public to read_only;
+
+GRANT read_only TO root;
+
+COMMIT;

--- a/sqitch/revert/add_read_only_user.sql
+++ b/sqitch/revert/add_read_only_user.sql
@@ -1,0 +1,7 @@
+-- Revert floq:add_read_only_user from pg
+
+BEGIN;
+
+DROP USER IF EXISTS read_only;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -82,3 +82,4 @@ add_employee_user 2019-10-30T13:28:19Z Trond Øydna <trond@trond-ubuntu> # Addin
 enable_employee_row_level_security 2019-10-30T13:21:20Z Trond Øydna <trond@trond-ubuntu> # Enabling row level security for employee user
 drop_timelock_view 2019-10-31T12:27:09Z Trond Øydna <trond@trond-ubuntu> # Dropping materialized view timelock_view
 revoke_write_grants_on_employee_role_from_employee 2019-10-31T14:06:51Z Trond Øydna <trond@trond-ubuntu> # Revoking grants to write on employee_role from employee
+add_read_only_user 2021-05-04T14:56:53Z Terje Uglebakken <terje.uglebakken@blank.no> # Add read only user

--- a/sqitch/verify/add_read_only_user.sql
+++ b/sqitch/verify/add_read_only_user.sql
@@ -1,0 +1,9 @@
+-- Verify floq:add_read_only_user on pg
+
+BEGIN;
+
+-- divide-by-zero if user does not exist
+SELECT 1/COUNT(*) FROM pg_catalog.pg_user
+WHERE usename = 'read_only' AND passwd IS NOT NULL;
+
+ROLLBACK;


### PR DESCRIPTION
I førsteomgang skal denne brukes for å gi API tilgang i Google Apps Scripts. For eksempel å holde ansatt sheet i Drive oppdatert. Se også [floq/#34](https://github.com/blankoslo/floq/pull/34).