### PR TITLE
feat(employees): Add hr_manager to employee table

### DIFF
--- a/sqitch/deploy/alter_table_employees_add_hr_manager.sql
+++ b/sqitch/deploy/alter_table_employees_add_hr_manager.sql
@@ -4,6 +4,7 @@ BEGIN;
 
 ALTER TABLE employees
     ADD COLUMN hr_manager INTEGER REFERENCES employees(id) ON UPDATE NO ACTION ON DELETE SET NULL;
+    GRANT SELECT ON employees TO employee;
 
 COMMIT;
 -- 

--- a/sqitch/deploy/alter_table_employees_add_hr_manager.sql
+++ b/sqitch/deploy/alter_table_employees_add_hr_manager.sql
@@ -1,0 +1,9 @@
+-- Deploy floq:alter_table_employees_add_hr_manager to pg
+
+BEGIN;
+
+ALTER TABLE employees
+    ADD COLUMN hr_manager INTEGER REFERENCES employees(id) ON UPDATE NO ACTION ON DELETE SET NULL;
+
+COMMIT;
+-- 

--- a/sqitch/revert/alter_table_employees_add_hr_manager.sql
+++ b/sqitch/revert/alter_table_employees_add_hr_manager.sql
@@ -4,5 +4,6 @@ BEGIN;
 
 ALTER TABLE employees
     DROP COLUMN hr_manager;
+    REVOKE SELECT ON employees TO employee;
 
 COMMIT;

--- a/sqitch/revert/alter_table_employees_add_hr_manager.sql
+++ b/sqitch/revert/alter_table_employees_add_hr_manager.sql
@@ -1,0 +1,8 @@
+-- Revert floq:alter_table_employees_add_hr_manager from pg
+
+BEGIN;
+
+ALTER TABLE employees
+    DROP COLUMN hr_manager;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -83,4 +83,4 @@ enable_employee_row_level_security 2019-10-30T13:21:20Z Trond Øydna <trond@tron
 drop_timelock_view 2019-10-31T12:27:09Z Trond Øydna <trond@trond-ubuntu> # Dropping materialized view timelock_view
 revoke_write_grants_on_employee_role_from_employee 2019-10-31T14:06:51Z Trond Øydna <trond@trond-ubuntu> # Revoking grants to write on employee_role from employee
 add_read_only_user 2021-05-04T14:56:53Z Terje Uglebakken <terje.uglebakken@blank.no> # Add read only user
-alter_table_employees_add_hr_manager 2021-09-24T09:20:13Z root <root@16759d20384e> # Alter employee table with hr manager
+alter_table_employees_add_hr_manager 2021-09-24T09:20:13Z Zaim Imran <zaim.imran@blank.no> # Alter employee table with hr manager

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -83,3 +83,4 @@ enable_employee_row_level_security 2019-10-30T13:21:20Z Trond Øydna <trond@tron
 drop_timelock_view 2019-10-31T12:27:09Z Trond Øydna <trond@trond-ubuntu> # Dropping materialized view timelock_view
 revoke_write_grants_on_employee_role_from_employee 2019-10-31T14:06:51Z Trond Øydna <trond@trond-ubuntu> # Revoking grants to write on employee_role from employee
 add_read_only_user 2021-05-04T14:56:53Z Terje Uglebakken <terje.uglebakken@blank.no> # Add read only user
+alter_table_employees_add_hr_manager 2021-09-24T09:20:13Z root <root@16759d20384e> # Alter employee table with hr manager

--- a/sqitch/verify/alter_table_employees_add_hr_manager.sql
+++ b/sqitch/verify/alter_table_employees_add_hr_manager.sql
@@ -1,0 +1,7 @@
+-- Verify floq:alter_table_employees_add_hr_manager on pg
+
+BEGIN;
+
+SELECT hr_manager FROM employees;
+
+ROLLBACK;


### PR DESCRIPTION
For [Trak](https://github.com/blankoslo/Trak) it's important that the information about HR managers is in the database. 
With this in mind i have extended the `employee`-table to itself with the name `hr_manager`. This is a nullable field and should not break any existing projects, as well as implemented ON DELETE SET NULL for further development  