### PR TITLE
Update view of project responsible for all employees

### DIFF
--- a/sqitch/deploy/update_view_employee_project_responsible.sql
+++ b/sqitch/deploy/update_view_employee_project_responsible.sql
@@ -1,0 +1,29 @@
+-- Deploy floq:update_view_employee_project_responsible to pg
+
+BEGIN;
+
+CREATE OR REPLACE VIEW employee_project_responsible AS
+SELECT most_staffed.employee as employee,
+       projects.responsible as project_responsible
+FROM (SELECT employee,
+             project
+      FROM (SELECT employee,
+                   project,
+                   total,
+                   row_number() OVER (PARTITION BY employee ORDER BY total DESC) as rank
+            FROM (SELECT employee,
+                         project,
+                         count(employee) AS total
+                  FROM staffing
+                  WHERE date > (now() - '22 days'::interval)
+                    AND date < (now() + '21 days'::interval)
+                    AND project != 'FER1000'
+                    AND EXISTS (SELECT id
+                      FROM projects
+                      WHERE projects.id = staffing.project
+                    AND active = true)
+                  GROUP BY employee, project) AS staffed_project) ranked
+      WHERE ranked.rank = 1) AS most_staffed
+         JOIN projects ON most_staffed.project = projects.id;
+
+COMMIT;

--- a/sqitch/revert/update_view_employee_project_responsible.sql
+++ b/sqitch/revert/update_view_employee_project_responsible.sql
@@ -1,0 +1,28 @@
+-- Revert floq:update_view_employee_project_responsible from pg
+
+BEGIN;
+
+CREATE OR REPLACE VIEW employee_project_responsible AS
+SELECT most_staffed.employee as employee,
+       projects.responsible as project_responsible
+FROM (SELECT employee,
+             project
+      FROM (SELECT employee,
+                   project,
+                   total,
+                   row_number() OVER (PARTITION BY employee ORDER BY total DESC) as rank
+            FROM (SELECT employee,
+                         project,
+                         count(employee) AS total
+                  FROM staffing
+                  WHERE date > (now() - '15 days'::interval)
+                    AND date < (now() + '14 days'::interval)
+                    AND EXISTS (SELECT id
+                      FROM projects
+                      WHERE projects.id = staffing.project
+                    AND active = true)
+                  GROUP BY employee, project) AS staffed_project) ranked
+      WHERE ranked.rank = 1) AS most_staffed
+         JOIN projects ON most_staffed.project = projects.id;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -89,3 +89,4 @@ add_trak_read_only_user 2022-08-14T10:28:27Z Isak Grande Bjørnstad <isak@Isaks-
 change_jwt_claim_retrieval 2023-11-30T09:24:47Z root Sigbjørn Myhre <root@c2205c5a0521> # Change JWT claim retrieval
 add_view_employee_project_responsible 2024-05-16T12:40:19Z root <root@995ca6998281> # Add a view over the project responsible for each employee
 grant_select_on_employee_responsible_view_trak_read_only 2024-06-03T07:40:38Z root <root@05674ad6324a> # Grant select to trak_read_only for employee_project_responsible view
+update_view_employee_project_responsible 2024-06-13T08:21:07Z root <root@86f76b9c44ce> # Update employee_project_responsible view with new rules for determining project responsible

--- a/sqitch/verify/update_view_employee_project_responsible.sql
+++ b/sqitch/verify/update_view_employee_project_responsible.sql
@@ -1,0 +1,7 @@
+-- Verify floq:update_view_employee_project_responsible on pg
+
+BEGIN;
+
+SELECT * FROM employee_project_responsible WHERE false;
+
+ROLLBACK;


### PR DESCRIPTION
Rules for determining project responsible set to what the employee has been staffed in the period last three weeks plus future three weeks. The project FER1000, which is vacation, has been excluded.