### PR TITLE
Add staffing percentage and staffing in period + target for local db

### DIFF
--- a/functions/add_staffing_in_period.sql
+++ b/functions/add_staffing_in_period.sql
@@ -24,8 +24,8 @@ BEGIN
 				in_project AS project,
 				in_percentage AS percentage
 			FROM weekdays
-			LEFT JOIN staffing s ON s.employee = in_employee AND s.date = weekdays.cur_date
-			WHERE s.date IS NULL
+			LEFT JOIN staffing s ON s.employee = in_employee AND s.date = weekdays.cur_date AND s.project = in_project
+			WHERE s.employee IS NULL
 			RETURNING date
  		)
  		SELECT date FROM new_staffing

--- a/functions/add_staffing_in_period.sql
+++ b/functions/add_staffing_in_period.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE FUNCTION public.add_staffing_in_period(in_employee integer, in_project text, start_date date, end_date date, in_percentage integer DEFAULT 100)
+ RETURNS SETOF date
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+	RETURN QUERY (
+		WITH RECURSIVE date_range AS (
+			SELECT start_date::date AS cur_date
+			UNION ALL
+			SELECT cur_date + 1
+			FROM date_range
+			WHERE cur_date < end_date::date
+		),
+		weekdays AS (
+			SELECT cur_date
+			FROM date_range
+			WHERE EXTRACT(DOW FROM cur_date) BETWEEN 1 AND 5
+		),
+		new_staffing AS (
+			INSERT INTO staffing (employee, date, project, percentage)
+			SELECT
+				in_employee AS employee,
+				weekdays.cur_date AS date,
+				in_project AS project,
+				in_percentage AS percentage
+			FROM weekdays
+			LEFT JOIN staffing s ON s.employee = in_employee AND s.date = weekdays.cur_date
+			WHERE s.date IS NULL
+			RETURNING date
+ 		)
+ 		SELECT date FROM new_staffing
+	);
+END
+$function$

--- a/sqitch/deploy/alter_table_staffing_add_staffing_percentage.sql
+++ b/sqitch/deploy/alter_table_staffing_add_staffing_percentage.sql
@@ -5,6 +5,6 @@ BEGIN;
 ALTER TABLE staffing
     DROP CONSTRAINT staffing_pkey,
     ADD COLUMN percentage INT NOT NULL DEFAULT 100,
-    ADD PRIMARY KEY (employee, date, percentage);
+    ADD PRIMARY KEY (employee, project, date);
 
 COMMIT;

--- a/sqitch/deploy/alter_table_staffing_add_staffing_percentage.sql
+++ b/sqitch/deploy/alter_table_staffing_add_staffing_percentage.sql
@@ -1,0 +1,10 @@
+-- Deploy floq:alter_table_staffing_add_staffing_percentage to pg
+
+BEGIN;
+
+ALTER TABLE staffing
+    DROP CONSTRAINT staffing_pkey,
+    ADD COLUMN percentage INT NOT NULL DEFAULT 100,
+    ADD PRIMARY KEY (employee, date, percentage);
+
+COMMIT;

--- a/sqitch/revert/alter_table_staffing_add_staffing_percentage.sql
+++ b/sqitch/revert/alter_table_staffing_add_staffing_percentage.sql
@@ -1,0 +1,9 @@
+-- Revert floq:alter_table_staffing_add_staffing_percentage from pg
+
+BEGIN;
+
+DROP CONSTRAINT staffing_pkey;
+DROP COLUMN percentage;
+ADD PRIMARY KEY staffing pkey(employee, date);
+
+COMMIT;

--- a/sqitch/revert/alter_table_staffing_add_staffing_percentage.sql
+++ b/sqitch/revert/alter_table_staffing_add_staffing_percentage.sql
@@ -2,8 +2,9 @@
 
 BEGIN;
 
-DROP CONSTRAINT staffing_pkey;
-DROP COLUMN percentage;
-ADD PRIMARY KEY staffing pkey(employee, date);
+ALTER TABLE staffing
+    DROP CONSTRAINT staffing_pkey,
+    DROP COLUMN percentage,
+    ADD PRIMARY KEY (employee, date);
 
 COMMIT;

--- a/sqitch/sqitch.conf
+++ b/sqitch/sqitch.conf
@@ -1,5 +1,7 @@
 [core]
 	engine = pg
+[target "floq-local"]
+	uri = db:pg://root@localhost/floq
 [target "floq-dev"]
 	uri = db:pg://root@floq-dev.caawuzisqucy.eu-central-1.rds.amazonaws.com/floq
 [target "floq-test"]

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -91,3 +91,4 @@ add_view_employee_project_responsible 2024-05-16T12:40:19Z root <root@995ca69982
 grant_select_on_employee_responsible_view_trak_read_only 2024-06-03T07:40:38Z root <root@05674ad6324a> # Grant select to trak_read_only for employee_project_responsible view
 update_view_employee_project_responsible 2024-06-13T08:21:07Z root <root@86f76b9c44ce> # Update employee_project_responsible view with new rules for determining project responsible
 alter_time_entry_use_btree_index_and_add_employee_date_composite_index 2024-07-10T14:13:21Z Isak Grande Bjørnstad <isak@Isaks-MacBook-Pro.local> # Change index type on time_entry from brim to btree. Also add a (employee, date) composite index
+alter_table_staffing_add_staffing_percentage 2024-09-27T09:55:56Z Petter Juterud Barhaugen <petter@Petter-sin-MacBook-Pro> # Add staffing percentage and allow multiple projects per employee per day

--- a/sqitch/verify/alter_table_staffing_add_staffing_percentage.sql
+++ b/sqitch/verify/alter_table_staffing_add_staffing_percentage.sql
@@ -1,0 +1,7 @@
+-- Verify floq:alter_table_staffing_add_staffing_percentage on pg
+
+BEGIN;
+
+SELECT employee, date, percentage FROM staffing WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
Added staffing percentage to staffing table, which is backwards compatible with existing values because of the default value being set to 100%.
Also changed the primary key to be unique to (employee, date, percentage), so that an employee can be staffed on multiple projects a day.
There is also a new function for adding staffing in a period of time, which will automatically compute the weekdays. Please notice that this does not yet take into account the employee's availability during those dates.