### PR TITLE
updated reporting functions

### DIFF
--- a/functions/reporting_functions.sql
+++ b/functions/reporting_functions.sql
@@ -6,72 +6,91 @@ RETURNS TABLE (available_hours numeric, billable_hours numeric, nonbillable_hour
 $$
 BEGIN
   RETURN QUERY (
-SELECT
-    (SELECT COUNT(work_day) * 7.5 as avail_hours FROM possible_work_dates_per_employee(from_date, to_date)) AS available_hours,
-    SUM(CASE WHEN staff.billable = 'billable' :: time_status THEN 1 ELSE 0 END) * 7.5 AS billable_hours,
-    SUM(CASE WHEN staff.billable = 'nonbillable' :: time_status THEN 1 ELSE 0 END) * 7.5 AS nonbillable_hours,
-    SUM(CASE WHEN staff.billable = 'unavailable' :: time_status THEN 1 ELSE 0 END) * 7.5 AS unavailable_hours
-  FROM (SELECT * FROM staffing
-    JOIN projects ON (staffing.project = projects.id)
-    WHERE staffing.date BETWEEN from_date AND to_date) AS staff
-
+  WITH daily_hours AS (
+    SELECT
+      date,
+      employee,
+      SUM(CASE WHEN p.billable = 'billable' THEN s.percentage * 0.075 ELSE 0 END) AS billable,
+      SUM(CASE WHEN p.billable = 'nonbillable' THEN s.percentage * 0.075 ELSE 0 END) AS nonbillable,
+      SUM(CASE WHEN p.billable = 'unavailable' THEN s.percentage * 0.075 ELSE 0 END) AS unavailable
+    FROM staffing s
+    JOIN projects p ON s.project = p.id
+    WHERE s.date BETWEEN from_date AND to_date
+    GROUP BY date,employee
+  ),
+  absence_hours AS (
+    SELECT
+      date,
+      employee_id AS employee,
+      SUM(CASE WHEN ar.billable = 'unavailable' :: time_status THEN a.percentage * 0.075 ELSE 0 END) as unavailable
+      FROM absence a
+      JOIN absence_reasons ar ON ar.id = a.reason
+      WHERE a.date BETWEEN from_date AND to_date
+      GROUP BY date, employee_id
+  ),
+  total_hours AS (
+    SELECT
+      COALESCE(d.date, a.date) AS date,
+      COALESCE(d.employee, a.employee) AS employee,
+      COALESCE(d.billable, 0) AS billable,
+      COALESCE(d.nonbillable, 0) + COALESCE(a.unavailable, 0) AS unavailable
+    FROM daily_hours d
+    FULL OUTER JOIN absence_hours a
+      ON d.date = a.date AND d.employee = a.employee
+  )
+  SELECT
+    (SELECT SUM(available_hours) FROM possible_work_hours_per_employee(from_date, to_date)) AS available_hours,
+    SUM(billable) AS billable_hours,
+    SUM(nonbillable) AS nonbillable_hours,
+    SUM(unavailable) AS unavailable_hours
+  FROM total_hours
   );
 END
 $$ LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION possible_work_dates_per_employee(from_date date, to_date date)
-RETURNS TABLE (employee_id integer, work_day date) AS
+CREATE OR REPLACE FUNCTION possible_work_hours_per_employee(from_date date, to_date date)
+RETURNS TABLE (employee_id integer, avail_hours numeric) AS
 $$
 BEGIN
   RETURN QUERY (
+    WITH possible_work_days AS (
+      SELECT
+        e.id AS employee_id,
+        generate_series::DATE AS work_day
+      FROM employees e
+      CROSS JOIN generate_series(from_date, to_date, '1 day'::interval)
+      WHERE is_weekday(generate_series::DATE)
+        AND NOT is_holiday(generate_series::DATE)
+        AND generate_series::DATE >= e.date_of_employment
+        AND (e.termination_date IS NULL OR generate_series::DATE <= e.termination_date)
+    ),
+    daily_percentages AS (
     SELECT
-      x.emp_id,
-      x.work_day
-    FROM
-      (SELECT
-         e.id                    AS emp_id,
-         e.first_name,
-         e.last_name,
-         generate_series :: DATE AS work_day
-       FROM employees e
-         CROSS JOIN
-           generate_series(from_date, to_date, '1 day' :: interval)
-      ) AS x
-    WHERE
-      is_possible_work_day(x.emp_id, x.work_day)
-  );
-END
-$$ LANGUAGE plpgsql;
-
-
-CREATE OR REPLACE FUNCTION is_possible_work_day(in_employee_id numeric, in_date date)
-  RETURNS BOOLEAN AS
-$$
-BEGIN
-  RETURN (
-    is_weekday(in_date)
-    AND NOT is_holiday(in_date)
-    AND NOT EXISTS(SELECT *
-                   FROM employees e
-                   WHERE e.id = in_employee_id AND e.termination_date < in_date)
-    AND EXISTS(SELECT *
-               FROM employees e
-               WHERE e.id = in_employee_id AND e.date_of_employment <= in_date)
-    AND (
-      NOT EXISTS(SELECT *
-                 FROM staffing s
-                 WHERE s.employee = in_employee_id AND s.date = in_date)
-      OR EXISTS(SELECT *
-                FROM staffing s
-                  JOIN projects p ON s.project = p.id
-                WHERE s.employee = in_employee_id AND s.date = in_date AND p.billable != 'unavailable' :: time_status)
+      days.employee_id,
+      days.work_day,
+      COALESCE(s.percentage, 0) AS staffing_percentage,
+      COALESCE(a.percentage, 0) AS absence_percentage
+    FROM possible_work_days days
+    LEFT JOIN (
+          SELECT employee, date, SUM(percentage) AS percentage
+          FROM staffing
+          GROUP BY employee, date
+      ) s ON days.employee_id = s.employee AND days.work_day = s.date
+      LEFT JOIN(
+          SELECT employee_id, date, SUM(percentage) AS percentage
+          FROM absence
+          GROUP BY employee_id, date
+      ) a ON days.employee_id = a.employee_id AND days.work_day = a.date
     )
-    AND NOT EXISTS(SELECT *
-                   FROM absence a
-                     JOIN absence_reasons ar ON (ar.id = a.reason)
-                   WHERE
-                     a.employee_id = in_employee_id AND a.date = in_date AND ar.billable = 'unavailable' :: time_status)
+    SELECT
+      employee_id,
+      7.5 - COALESCE(
+          (staffing_percentage * 0.075) -
+          (GREATEST(staffing_percentage + absence_percentage - 100, 0) * 0.075),
+        0
+      ) AS available_hours
+    FROM daily_percentages
   );
 END
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Why

We have moved to a new model for staffing, and need to update the functions that have to do with status to reflect the changes.
These key changes have been made:

- The `staffing` and `absence` tables now have a `percentage` column to represent their respective staffing levels.
- Absence will overlap projects, so that employees can be staffed uninterrupted for as long as their contract is valid. This makes it a lot easier to handle situations where employees undo an addition of absence, because we can "fall back" to the original staffing. However, this means that simply counting every day with staffing present in the table will overestimate the staffing hours, as absence can "override" it.


## How

### Percentage levels and absence overlap:

Instead of counting every day and multiplying by 7.5, we now count hours based on the percentage of staffing/absence (100% = 7.5 hours).
Absence percentage always overrides staffing, so if someone is 50% staffed, 90% absent, only the staffing percentage will be affected.

The math for getting staffing hours in one day works out to be something like this:
```
absence hours = absence_percentage * 0.075
staffing hours = MIN( staffing_percentage, absence_percentage - 100) * 0.075
```

*Availability* is calculated differently, as everything except absence or staffing with an `unavailable` reason/project is counted as available time.
```
available hours = MAX( 100 - staffing_unavailable_percentage - absent_unavailable_percentage, 0 ) * 0.075
```