### PR TITLE
Add comments for time entry

### DIFF
--- a/sqitch/deploy/add_time_entry_comments_table.sql
+++ b/sqitch/deploy/add_time_entry_comments_table.sql
@@ -1,0 +1,22 @@
+-- Deploy floq:add_time_entry_comments_table to pg
+-- requires: time_tracking_tables
+-- requires: enable_employee_row_level_security
+
+BEGIN;
+
+CREATE TABLE time_entry_comments (
+    id       TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
+    employee INTEGER NOT NULL REFERENCES employees(id),
+    creator  INTEGER NOT NULL REFERENCES employees(id),
+    comment  TEXT NOT NULL,
+    project  TEXT NOT NULL REFERENCES projects(id),
+    date     DATE NOT NULL,
+    created  TIMESTAMP WITHOUT TIME ZONE DEFAULT now(),
+    UNIQUE (employee, project, date)
+);
+
+GRANT ALL PRIVILEGES ON TABLE time_entry_comments TO employee;
+
+SELECT enable_default_row_level_security('time_entry_comments', 'check_employee_write_access(employee)');
+
+COMMIT;

--- a/sqitch/revert/add_time_entry_comments_table.sql
+++ b/sqitch/revert/add_time_entry_comments_table.sql
@@ -1,0 +1,9 @@
+-- Revert floq:add_time_entry_comments_table from pg
+
+BEGIN;
+
+DROP POLICY IF EXISTS time_entry_comments_select_policy ON time_entry_comments;
+DROP POLICY IF EXISTS time_entry_comments_write_policy ON time_entry_comments;
+DROP TABLE IF EXISTS time_entry_comments;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -96,3 +96,4 @@ alter_table_absence_add_percentage 2024-11-28T12:03:26Z Petter Juterud Barhaugen
 remove_absence_from_staffing 2025-01-23T14:00:30Z Simen Viken Grini <simen.grini@blank.no> # move all absence from the staffing table to the absence table
 add_view_available_projects 2025-09-08T07:59:11Z Petter Juterud Barhaugen <petter@Petter-sin-MacBook-Pro> # Add new available_projects view which omits absence reasons
 add_employee_tenure_role_table [employees_table enable_employee_row_level_security] 2026-03-12T11:55:23Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add employee_tenure_role table
+add_time_entry_comments_table [time_tracking_tables enable_employee_row_level_security] 2026-04-10T10:15:62Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add time_entry_comments table for per-employee/project/date comments

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -96,4 +96,4 @@ alter_table_absence_add_percentage 2024-11-28T12:03:26Z Petter Juterud Barhaugen
 remove_absence_from_staffing 2025-01-23T14:00:30Z Simen Viken Grini <simen.grini@blank.no> # move all absence from the staffing table to the absence table
 add_view_available_projects 2025-09-08T07:59:11Z Petter Juterud Barhaugen <petter@Petter-sin-MacBook-Pro> # Add new available_projects view which omits absence reasons
 add_employee_tenure_role_table [employees_table enable_employee_row_level_security] 2026-03-12T11:55:23Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add employee_tenure_role table
-add_time_entry_comments_table [time_tracking_tables enable_employee_row_level_security] 2026-04-10T10:15:62Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add time_entry_comments table for per-employee/project/date comments
+add_time_entry_comments_table [time_tracking_tables enable_employee_row_level_security] 2026-04-10T10:43:02Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add time_entry_comments table for per-employee/project/date comments

--- a/sqitch/verify/add_time_entry_comments_table.sql
+++ b/sqitch/verify/add_time_entry_comments_table.sql
@@ -1,0 +1,10 @@
+-- Verify floq:add_time_entry_comments_table on pg
+
+BEGIN;
+
+SELECT * FROM time_entry_comments;
+
+-- divide-by-zero if policy does not exist
+SELECT 1/COUNT(*) FROM pg_catalog.pg_policies WHERE tablename = 'time_entry_comments';
+
+ROLLBACK;


### PR DESCRIPTION
Det er ønskelig å kunne kommentere på en enkelt timeføring. Dette er løst med en egen tabell for dette som er lik `time_entry` der `minutes` er byttet ut med `comment`. Den har også en restriksjon på én kommentar per celle.

Litt design for å forklare:

<img width="337" height="560" alt="Skjermbilde 2026-04-10 kl  12 11 26" src="https://github.com/user-attachments/assets/b18b1076-a9cf-4909-b722-505cfa653860" />
