### PR TITLE
Legger til invoice_lock_events table

### DIFF
--- a/sqitch/deploy/add_invoice_lock_events_table.sql
+++ b/sqitch/deploy/add_invoice_lock_events_table.sql
@@ -13,4 +13,6 @@ CREATE TABLE invoice_lock_events (
     commit_date DATE NOT NULL
 );
 
+GRANT ALL PRIVILEGES ON TABLE invoice_lock_events TO employee;
+
 COMMIT;

--- a/sqitch/deploy/add_invoice_lock_events_table.sql
+++ b/sqitch/deploy/add_invoice_lock_events_table.sql
@@ -1,0 +1,16 @@
+-- Deploy floq:add_invoice_lock_events_table to pg
+-- requires: time_tracking_tables
+-- requires: employees_table
+
+BEGIN;
+
+CREATE TABLE invoice_lock_events (
+    id          TEXT CONSTRAINT invoice_lock_events_pkey PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_id  TEXT NOT NULL REFERENCES projects(id),
+    creator_id  INTEGER NOT NULL REFERENCES employees(id),
+    created_at  TIMESTAMP NOT NULL DEFAULT now(),
+    order_id    INTEGER NOT NULL,
+    commit_date DATE NOT NULL
+);
+
+COMMIT;

--- a/sqitch/revert/add_invoice_lock_events_table.sql
+++ b/sqitch/revert/add_invoice_lock_events_table.sql
@@ -1,0 +1,7 @@
+-- Revert floq:add_invoice_lock_events_table from pg
+
+BEGIN;
+
+DROP TABLE invoice_lock_events;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -98,3 +98,4 @@ add_view_available_projects 2025-09-08T07:59:11Z Petter Juterud Barhaugen <pette
 add_employee_tenure_role_table [employees_table enable_employee_row_level_security] 2026-03-12T11:55:23Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add employee_tenure_role table
 add_time_entry_comments_table [time_tracking_tables enable_employee_row_level_security] 2026-04-10T10:43:02Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add time_entry_comments table for per-employee/project/date comments
 add_tripletex_customer_number_to_customer_table 2026-04-23T10:57:14Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add tripletex customer number to customer table
+add_invoice_lock_events_table [time_tracking_tables employees_table] 2026-04-27T12:02:51Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add table invoice_lock_events

--- a/sqitch/verify/add_invoice_lock_events_table.sql
+++ b/sqitch/verify/add_invoice_lock_events_table.sql
@@ -1,0 +1,7 @@
+-- Verify floq:add_invoice_lock_events_table on pg
+
+BEGIN;
+
+SELECT id, project_id, creator_id, created_at, order_id, commit_date FROM invoice_lock_events;
+
+ROLLBACK;


### PR DESCRIPTION
Oppretter ny tabell. Denne skal holde styr på hvilke prosjekter vi har opprettet en ordre på til hvilken måned (i tillegg til hvem som har gjort det når).