### PR TITLE
Add contact columns, project_members table, and subcontractor flag

### DIFF
--- a/sqitch/deploy/alter_table_customers_add_contact_columns.sql
+++ b/sqitch/deploy/alter_table_customers_add_contact_columns.sql
@@ -6,7 +6,6 @@
 BEGIN;
 
 ALTER TABLE customers
-  ADD COLUMN is_subcontractor     boolean NOT NULL DEFAULT false,
   ADD COLUMN account_manager      integer REFERENCES employees(id),
   ADD COLUMN tripletex_contact_id integer;
 

--- a/sqitch/deploy/alter_table_customers_add_contact_columns.sql
+++ b/sqitch/deploy/alter_table_customers_add_contact_columns.sql
@@ -1,0 +1,13 @@
+-- Deploy floq:alter_table_customers_add_contact_columns to pg
+-- requires: time_tracking_tables
+-- requires: employees_table
+-- requires: add_tripletex_customer_number_to_customer_table
+
+BEGIN;
+
+ALTER TABLE customers
+  ADD COLUMN is_subcontractor     boolean NOT NULL DEFAULT false,
+  ADD COLUMN account_manager      integer REFERENCES employees(id),
+  ADD COLUMN tripletex_contact_id integer;
+
+COMMIT;

--- a/sqitch/deploy/alter_table_projects_add_subcontractor_flag.sql
+++ b/sqitch/deploy/alter_table_projects_add_subcontractor_flag.sql
@@ -3,6 +3,8 @@
 
 BEGIN;
 
-ALTER TABLE projects ADD COLUMN has_subcontractor_consultants boolean NOT NULL DEFAULT false;
+ALTER TABLE projects
+  ADD COLUMN has_subcontractor_consultants boolean NOT NULL DEFAULT false,
+  ADD COLUMN is_subcontractor              boolean NOT NULL DEFAULT false;
 
 COMMIT;

--- a/sqitch/deploy/alter_table_projects_add_subcontractor_flag.sql
+++ b/sqitch/deploy/alter_table_projects_add_subcontractor_flag.sql
@@ -1,0 +1,8 @@
+-- Deploy floq:alter_table_projects_add_subcontractor_flag to pg
+-- requires: time_tracking_tables
+
+BEGIN;
+
+ALTER TABLE projects ADD COLUMN has_subcontractor_consultants boolean NOT NULL DEFAULT false;
+
+COMMIT;

--- a/sqitch/deploy/create_project_members_table.sql
+++ b/sqitch/deploy/create_project_members_table.sql
@@ -5,14 +5,13 @@
 BEGIN;
 
 CREATE TABLE project_members (
-  id          SERIAL PRIMARY KEY,
   employee_id integer NOT NULL REFERENCES employees(id),
   customer_id text    NOT NULL REFERENCES customers(id),
   hourly_rate numeric NOT NULL,
-  from_date   date    NOT NULL
+  from_date   date    NOT NULL,
+  PRIMARY KEY (employee_id, customer_id, from_date)
 );
 
 GRANT ALL PRIVILEGES ON TABLE project_members TO employee;
-GRANT ALL PRIVILEGES ON SEQUENCE project_members_id_seq TO employee;
 
 COMMIT;

--- a/sqitch/deploy/create_project_members_table.sql
+++ b/sqitch/deploy/create_project_members_table.sql
@@ -6,7 +6,7 @@ BEGIN;
 
 CREATE TABLE project_members (
   id            SERIAL PRIMARY KEY,
-  consultant_id integer NOT NULL REFERENCES employees(id),
+  employee_id   integer NOT NULL REFERENCES employees(id),
   project_id    text    NOT NULL REFERENCES projects(id),
   hourly_rate   numeric NOT NULL,
   from_date     date    NOT NULL,

--- a/sqitch/deploy/create_project_members_table.sql
+++ b/sqitch/deploy/create_project_members_table.sql
@@ -7,7 +7,7 @@ BEGIN;
 CREATE TABLE project_members (
   id          SERIAL PRIMARY KEY,
   employee_id integer NOT NULL REFERENCES employees(id),
-  customer_id integer NOT NULL REFERENCES customers(id),
+  customer_id text    NOT NULL REFERENCES customers(id),
   hourly_rate numeric NOT NULL,
   from_date   date    NOT NULL
 );

--- a/sqitch/deploy/create_project_members_table.sql
+++ b/sqitch/deploy/create_project_members_table.sql
@@ -1,0 +1,19 @@
+-- Deploy floq:create_project_members_table to pg
+-- requires: employees_table
+-- requires: time_tracking_tables
+
+BEGIN;
+
+CREATE TABLE project_members (
+  id            SERIAL PRIMARY KEY,
+  consultant_id integer NOT NULL REFERENCES employees(id),
+  project_id    text    NOT NULL REFERENCES projects(id),
+  hourly_rate   numeric NOT NULL,
+  from_date     date    NOT NULL,
+  to_date       date
+);
+
+GRANT ALL PRIVILEGES ON TABLE project_members TO employee;
+GRANT ALL PRIVILEGES ON SEQUENCE project_members_id_seq TO employee;
+
+COMMIT;

--- a/sqitch/deploy/create_project_members_table.sql
+++ b/sqitch/deploy/create_project_members_table.sql
@@ -5,12 +5,11 @@
 BEGIN;
 
 CREATE TABLE project_members (
-  id            SERIAL PRIMARY KEY,
-  employee_id   integer NOT NULL REFERENCES employees(id),
-  project_id    text    NOT NULL REFERENCES projects(id),
-  hourly_rate   numeric NOT NULL,
-  from_date     date    NOT NULL,
-  to_date       date
+  id          SERIAL PRIMARY KEY,
+  employee_id integer NOT NULL REFERENCES employees(id),
+  customer_id integer NOT NULL REFERENCES customers(id),
+  hourly_rate numeric NOT NULL,
+  from_date   date    NOT NULL
 );
 
 GRANT ALL PRIVILEGES ON TABLE project_members TO employee;

--- a/sqitch/deploy/create_project_members_table.sql
+++ b/sqitch/deploy/create_project_members_table.sql
@@ -5,11 +5,11 @@
 BEGIN;
 
 CREATE TABLE project_members (
+  id          TEXT    CONSTRAINT project_members_pkey PRIMARY KEY DEFAULT uuid_generate_v4(),
   employee_id integer NOT NULL REFERENCES employees(id),
   customer_id text    NOT NULL REFERENCES customers(id),
   hourly_rate numeric NOT NULL,
-  from_date   date    NOT NULL,
-  PRIMARY KEY (employee_id, customer_id, from_date)
+  from_date   date    NOT NULL
 );
 
 GRANT ALL PRIVILEGES ON TABLE project_members TO employee;

--- a/sqitch/revert/alter_table_customers_add_contact_columns.sql
+++ b/sqitch/revert/alter_table_customers_add_contact_columns.sql
@@ -1,0 +1,10 @@
+-- Revert floq:alter_table_customers_add_contact_columns from pg
+
+BEGIN;
+
+ALTER TABLE customers
+  DROP COLUMN is_subcontractor,
+  DROP COLUMN account_manager,
+  DROP COLUMN tripletex_contact_id;
+
+COMMIT;

--- a/sqitch/revert/alter_table_customers_add_contact_columns.sql
+++ b/sqitch/revert/alter_table_customers_add_contact_columns.sql
@@ -3,7 +3,6 @@
 BEGIN;
 
 ALTER TABLE customers
-  DROP COLUMN is_subcontractor,
   DROP COLUMN account_manager,
   DROP COLUMN tripletex_contact_id;
 

--- a/sqitch/revert/alter_table_projects_add_subcontractor_flag.sql
+++ b/sqitch/revert/alter_table_projects_add_subcontractor_flag.sql
@@ -1,0 +1,7 @@
+-- Revert floq:alter_table_projects_add_subcontractor_flag from pg
+
+BEGIN;
+
+ALTER TABLE projects DROP COLUMN has_subcontractor_consultants;
+
+COMMIT;

--- a/sqitch/revert/alter_table_projects_add_subcontractor_flag.sql
+++ b/sqitch/revert/alter_table_projects_add_subcontractor_flag.sql
@@ -2,6 +2,8 @@
 
 BEGIN;
 
-ALTER TABLE projects DROP COLUMN has_subcontractor_consultants;
+ALTER TABLE projects
+  DROP COLUMN has_subcontractor_consultants,
+  DROP COLUMN is_subcontractor;
 
 COMMIT;

--- a/sqitch/revert/create_project_members_table.sql
+++ b/sqitch/revert/create_project_members_table.sql
@@ -1,0 +1,7 @@
+-- Revert floq:create_project_members_table from pg
+
+BEGIN;
+
+DROP TABLE project_members;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -99,3 +99,6 @@ add_employee_tenure_role_table [employees_table enable_employee_row_level_securi
 add_time_entry_comments_table [time_tracking_tables enable_employee_row_level_security] 2026-04-10T10:43:02Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add time_entry_comments table for per-employee/project/date comments
 add_tripletex_customer_number_to_customer_table 2026-04-23T10:57:14Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add tripletex customer number to customer table
 add_invoice_lock_events_table [time_tracking_tables employees_table] 2026-04-27T12:02:51Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add table invoice_lock_events
+alter_table_customers_add_contact_columns [time_tracking_tables employees_table add_tripletex_customer_number_to_customer_table] 2026-05-22T10:00:00Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add account_manager, tripletex_contact_id and is_subcontractor to customers
+create_project_members_table [employees_table time_tracking_tables] 2026-05-22T10:01:00Z Sander Magnussen Neraas <sander.neraas@blank.no> # Create project_members table
+alter_table_projects_add_subcontractor_flag [time_tracking_tables] 2026-05-22T10:02:00Z Sander Magnussen Neraas <sander.neraas@blank.no> # Add has_subcontractor_consultants flag to projects

--- a/sqitch/verify/alter_table_customers_add_contact_columns.sql
+++ b/sqitch/verify/alter_table_customers_add_contact_columns.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-SELECT is_subcontractor, account_manager, tripletex_contact_id FROM customers;
+SELECT account_manager, tripletex_contact_id FROM customers;
 
 ROLLBACK;

--- a/sqitch/verify/alter_table_customers_add_contact_columns.sql
+++ b/sqitch/verify/alter_table_customers_add_contact_columns.sql
@@ -1,0 +1,7 @@
+-- Verify floq:alter_table_customers_add_contact_columns on pg
+
+BEGIN;
+
+SELECT is_subcontractor, account_manager, tripletex_contact_id FROM customers;
+
+ROLLBACK;

--- a/sqitch/verify/alter_table_projects_add_subcontractor_flag.sql
+++ b/sqitch/verify/alter_table_projects_add_subcontractor_flag.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-SELECT has_subcontractor_consultants FROM projects;
+SELECT has_subcontractor_consultants, is_subcontractor FROM projects;
 
 ROLLBACK;

--- a/sqitch/verify/alter_table_projects_add_subcontractor_flag.sql
+++ b/sqitch/verify/alter_table_projects_add_subcontractor_flag.sql
@@ -1,0 +1,7 @@
+-- Verify floq:alter_table_projects_add_subcontractor_flag on pg
+
+BEGIN;
+
+SELECT has_subcontractor_consultants FROM projects;
+
+ROLLBACK;

--- a/sqitch/verify/create_project_members_table.sql
+++ b/sqitch/verify/create_project_members_table.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-SELECT employee_id, customer_id, hourly_rate, from_date FROM project_members;
+SELECT id, employee_id, customer_id, hourly_rate, from_date FROM project_members;
 
 ROLLBACK;

--- a/sqitch/verify/create_project_members_table.sql
+++ b/sqitch/verify/create_project_members_table.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-SELECT id, employee_id, project_id, hourly_rate, from_date, to_date FROM project_members;
+SELECT id, employee_id, customer_id, hourly_rate, from_date FROM project_members;
 
 ROLLBACK;

--- a/sqitch/verify/create_project_members_table.sql
+++ b/sqitch/verify/create_project_members_table.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-SELECT id, consultant_id, project_id, hourly_rate, from_date, to_date FROM project_members;
+SELECT id, employee_id, project_id, hourly_rate, from_date, to_date FROM project_members;
 
 ROLLBACK;

--- a/sqitch/verify/create_project_members_table.sql
+++ b/sqitch/verify/create_project_members_table.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-SELECT id, employee_id, customer_id, hourly_rate, from_date FROM project_members;
+SELECT employee_id, customer_id, hourly_rate, from_date FROM project_members;
 
 ROLLBACK;

--- a/sqitch/verify/create_project_members_table.sql
+++ b/sqitch/verify/create_project_members_table.sql
@@ -1,0 +1,7 @@
+-- Verify floq:create_project_members_table on pg
+
+BEGIN;
+
+SELECT id, consultant_id, project_id, hourly_rate, from_date, to_date FROM project_members;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

- `alter_table_customers_add_contact_columns`: adds `account_manager` (FK to employees) and `tripletex_contact_id` (external contact person in Tripletex)
- `create_project_members_table`: new table linking employees to customers with `hourly_rate` and `from_date`; rate is per employee per customer
- `alter_table_projects_add_subcontractor_flag`: adds `is_subcontractor` and `has_subcontractor_consultants` booleans to projects

## Test plan

- [ ] `sqitch deploy` applies all three migrations cleanly
- [ ] `sqitch verify` passes for all three
- [ ] `sqitch revert` rolls back cleanly, then redeploy succeeds