### PR TITLE
Add order_group_id to invoice_lock_events

### DIFF
--- a/sqitch/deploy/add_order_group_id_to_invoice_lock_events.sql
+++ b/sqitch/deploy/add_order_group_id_to_invoice_lock_events.sql
@@ -1,0 +1,8 @@
+-- Deploy floq:add_order_group_id_to_invoice_lock_events to pg
+-- requires: add_invoice_lock_events_table
+
+BEGIN;
+
+ALTER TABLE invoice_lock_events ADD COLUMN order_group_id INTEGER;
+
+COMMIT;

--- a/sqitch/revert/add_order_group_id_to_invoice_lock_events.sql
+++ b/sqitch/revert/add_order_group_id_to_invoice_lock_events.sql
@@ -1,0 +1,7 @@
+-- Revert floq:add_order_group_id_to_invoice_lock_events from pg
+
+BEGIN;
+
+ALTER TABLE invoice_lock_events DROP COLUMN order_group_id;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -108,3 +108,4 @@ alter_projects_table 2026-06-08T09:07:00Z sqitch <sergey@blank.no> # Alter proje
 add_time_entry_constraint 2026-06-08T15:10:48Z sqitch <sergey@blank.no> # Add constraint to time_entry table
 add_project_pins 2026-06-15T07:17:59Z Sergey Jakobsen <sergey@blank.no> # Add table to pin projects to employees
 add_internal_name_to_projects 2026-06-24T10:29:34Z Sergey Jakobsen <sergey@blank.no> # Add internal name to projects
+add_order_group_id_to_invoice_lock_events [add_invoice_lock_events_table] 2026-06-25T09:30:00Z Andreas Jonassen <andreas.jonassen@blank.no> # Add order_group_id to invoice_lock_events for per-project Tripletex reconciliation

--- a/sqitch/verify/add_order_group_id_to_invoice_lock_events.sql
+++ b/sqitch/verify/add_order_group_id_to_invoice_lock_events.sql
@@ -1,0 +1,7 @@
+-- Verify floq:add_order_group_id_to_invoice_lock_events on pg
+
+BEGIN;
+
+SELECT order_group_id FROM invoice_lock_events;
+
+ROLLBACK;


### PR DESCRIPTION
## What
Nullable `order_group_id` column on `invoice_lock_events` (sqitch deploy/revert/verify + plan entry).

## Why
Foundation for the cross-repo **invoiced-figures-from-Tripletex** feature in Avstemming (balance-v2). A Tripletex customer order holds one *order group* per project; recording that group id on each per-project lock event lets reports-api read each project's invoiced hours/fee back from the correct group. Older rows leave it null and are handled gracefully downstream (they fall back to manual values).

## Related PRs
One feature across three repos, landed in order — **this migration deploys first**:
1. **this PR** — the `order_group_id` column
2. blankoslo/floq-reports-api#25 — reads the column, serves `/invoice/invoiced`
3. blankoslo/floq-balance-v2#17 — consumes the endpoint